### PR TITLE
CI: Enforce pedantic warning flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,44 +1,54 @@
+# SPDX-License-Identifier: MIT
+# Research-only cube96 CI workflow enforcing strict compiler warnings.
 name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.compiler }} ${{ matrix.build_type }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        compiler: [gcc, clang]
+        build_type: [Debug, Release]
+    env:
+      BUILD_DIR: build/${{ matrix.compiler }}-${{ matrix.build_type }}
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup compiler
+        run: |
+          if [ "${{ matrix.compiler }}" = "gcc" ]; then
+            echo "CC=gcc" >> "$GITHUB_ENV"
+            echo "CXX=g++" >> "$GITHUB_ENV"
+          else
+            echo "CC=clang" >> "$GITHUB_ENV"
+            echo "CXX=clang++" >> "$GITHUB_ENV"
+          fi
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-ccache-${{ hashFiles('CMakeLists.txt', 'src/**/*.cpp', 'include/**/*.hpp') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-ccache-
+            ${{ runner.os }}-${{ matrix.compiler }}-
+
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        run: |
+          cmake -S . -B "$BUILD_DIR" \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
-        run: cmake --build build --config Release
+        run: cmake --build "$BUILD_DIR" --config ${{ matrix.build_type }}
 
-      - name: Run tests
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            ctest --test-dir build -C Release --output-on-failure
-          else
-            ctest --test-dir build --output-on-failure
-          fi
-        shell: bash
-
-      - name: Run benchmark (smoke)
-        run: |
-          cmake -E env CUBE96_BENCH_BYTES=65536 ./build/cube96_bench
-        shell: bash
-        if: matrix.os != 'windows-latest'
-
-      - name: Run benchmark (smoke, Windows)
-        run: |
-          cmake -E env CUBE96_BENCH_BYTES=65536 build/Release/cube96_bench.exe
-        if: matrix.os == 'windows-latest'
+      - name: Test
+        run: ctest --test-dir "$BUILD_DIR" --output-on-failure --build-config ${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,24 @@ add_library(cube96
   src/perm.cpp
   src/sbox.cpp)
 
+function(cube96_enable_strict_warnings target)
+  target_compile_options(${target} PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wextra>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wpedantic>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Werror>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wshadow>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wcast-align>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wformat=2>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4>
+    $<$<CXX_COMPILER_ID:MSVC>:/WX>)
+endfunction()
+
 target_include_directories(cube96 PUBLIC include)
 
 target_compile_features(cube96 PUBLIC cxx_std_17)
+
+cube96_enable_strict_warnings(cube96)
 
 set(CUBE96_LAYOUT "zslice" CACHE STRING "State layout mapping (zslice|rowmajor)")
 set_property(CACHE CUBE96_LAYOUT PROPERTY STRINGS zslice rowmajor)
@@ -31,9 +46,11 @@ endif()
 
 add_executable(cube96_cli tools/cube96_cli.cpp)
 target_link_libraries(cube96_cli PRIVATE cube96)
+cube96_enable_strict_warnings(cube96_cli)
 
 add_executable(cube96_bench bench/bench_throughput.cpp)
 target_link_libraries(cube96_bench PRIVATE cube96)
+cube96_enable_strict_warnings(cube96_bench)
 
 set(TEST_SOURCES
   tests/test_roundtrip.cpp
@@ -49,5 +66,6 @@ foreach(test_src IN LISTS TEST_SOURCES)
   get_filename_component(test_name ${test_src} NAME_WE)
   add_executable(${test_name} ${test_src})
   target_link_libraries(${test_name} PRIVATE cube96)
+  cube96_enable_strict_warnings(${test_name})
   add_test(NAME ${test_name} COMMAND ${test_name})
 endforeach()


### PR DESCRIPTION
## Why
- Keep the research cipher warning-clean across toolchains and configurations.

## What
- Added a reusable helper that enables strict warning levels with fail-on-warning semantics for GCC/Clang/MSVC targets.
- Applied the helper to the library, tools, and test executables.
- Introduced a GitHub Actions workflow that builds and tests Debug/Release with GCC and Clang while caching ccache artifacts.

## Risks
- Potential build breaks if new warnings are introduced by future code changes.

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`