### PR TITLE
Fix CI badge and shorten round-trip test runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cube96 Block Cipher
 
-[![CI](https://github.com/OWNER/96bit-block-cipher/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/96bit-block-cipher/actions/workflows/ci.yml)
+[![CI](https://github.com/96bit-block-cipher/96bit-block-cipher/actions/workflows/ci.yml/badge.svg)](https://github.com/96bit-block-cipher/96bit-block-cipher/actions/workflows/ci.yml)
 
 > ⚠️ **Research cipher — NOT FOR PRODUCTION.** The 96-bit parameters keep the
 > state space tractable for exploration and are not intended to meet modern
@@ -96,6 +96,10 @@ Unit tests are registered with CTest and carry labels for selective execution.
 ctest --test-dir build --output-on-failure
 ctest --test-dir build -L KAT --output-on-failure  # only known-answer tests
 ```
+
+The long-running `test_roundtrip` binary now defaults to 10,000 random
+round-trips to keep CI runs under the workflow timeout. Increase coverage
+locally by exporting `CUBE96_TEST_ITERATIONS=<count>` before invoking CTest.
 
 ## Command-line Interface
 

--- a/tests/test_roundtrip.cpp
+++ b/tests/test_roundtrip.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <cstdlib>
 #include <iostream>
 #include <random>
 #include <vector>
@@ -27,7 +28,17 @@ int main() {
   std::array<std::uint8_t, cube96::CubeCipher::BlockBytes> recovered{};
   std::array<std::uint8_t, cube96::CubeCipher::BlockBytes> baseline{};
 
-  const std::size_t iterations = 50000;
+  // Default to a 10k-sample sweep to balance coverage with CI runtime.  Allow
+  // overriding through an environment variable so developers can dial the
+  // iteration count up when investigating discrepancies locally.
+  std::size_t iterations = 10000;
+  if (const char *env = std::getenv("CUBE96_TEST_ITERATIONS")) {
+    char *end = nullptr;
+    unsigned long parsed = std::strtoul(env, &end, 10);
+    if (end != env && *end == '\0' && parsed > 0) {
+      iterations = static_cast<std::size_t>(parsed);
+    }
+  }
   for (std::size_t iter = 0; iter < iterations; ++iter) {
     for (auto &b : key) {
       b = static_cast<std::uint8_t>(dist(rng));


### PR DESCRIPTION
## Summary
- point the README CI badge at the actual workflow so the badge link works again
- trim the `test_roundtrip` iteration count to keep the suite under CI timeouts and allow overriding it via `CUBE96_TEST_ITERATIONS`
- document the new environment variable in the testing section of the README

## Testing
- ctest --test-dir build --output-on-failure
- ctest --test-dir build-ct --output-on-failure
- ctest --test-dir build-row-ct --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dc6a2199d08323a4221d89de9efa98